### PR TITLE
Fix key used to lookup settings

### DIFF
--- a/Sources/langsrvlib/SwiftLanguageServer.swift
+++ b/Sources/langsrvlib/SwiftLanguageServer.swift
@@ -109,7 +109,7 @@ public final class SwiftLanguageServer<TransportType: MessageProtocol> {
     }
 
     private func doWorkspaceDidChangeConfiguration(_ params: DidChangeConfigurationParams) throws {
-        let settings = (params.settings as! JSValue)["swift-langsrv"]
+        let settings = (params.settings as! JSValue)["swift"]
 
         guard let toolchainPath = settings["toolchainPath"].string else {
             throw "The path to the Toolchain must be set."


### PR DESCRIPTION
Fixes crashes due to force-unwrapping the `packageName` variable when processing a completion. This is never getting set because the `doWorkspaceDidChangeConfiguration()` method is throwing when it fails to load the `toolchainPath` [here](https://github.com/owensd/swift-langsrv/blob/master/Sources/langsrvlib/SwiftLanguageServer.swift#L114).

This is looking for settings at `settings["swift-langsrvr"]`, but it appears it is being sent `settings["swift"]`. I didn't see anywhere else this key was defined, so I'm assuming it's supposed to match the `package.json` config here - https://github.com/owensd/vscode-swift/blob/master/package.json#L60