### PR TITLE
Configure the workspace on initialize request not only on DidChangeConfiguration

### DIFF
--- a/Sources/langsrvlib/SwiftLanguageServer.swift
+++ b/Sources/langsrvlib/SwiftLanguageServer.swift
@@ -143,6 +143,8 @@ public final class SwiftLanguageServer<TransportType: MessageProtocol> {
         // capabilities.documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions(firstTriggerCharacter: "{", moreTriggerCharacter: nil)
         // capabilities.renameProvider = true
         // capabilities.documentLinkProvider = DocumentLinkOptions(resolveProvider: false)
+
+        try configureWorkspace(settings: nil)
         
         return .initialize(requestId: requestId, result: InitializeResult(capabilities: capabilities))
     }
@@ -154,7 +156,10 @@ public final class SwiftLanguageServer<TransportType: MessageProtocol> {
 
     private func doWorkspaceDidChangeConfiguration(_ params: DidChangeConfigurationParams) throws {
         let settings = (params.settings as! JSValue)[languageServerSettingsKey] ?? [:]
+        try configureWorkspace(settings: settings)
+    }
 
+    private func configureWorkspace(settings: JSValue?) throws {
         self.toolchainPath = getToolchainPath(settings)
         log("configuration: toolchainPath set to %{public}@", category: languageServerLogCategory, toolchainPath)
 
@@ -500,8 +505,8 @@ public final class SwiftLanguageServer<TransportType: MessageProtocol> {
         }
     }
 
-    private func getToolchainPath(_ settings: JSValue) -> String {
-        if let toolchainPath = settings["toolchainPath"].string {
+    private func getToolchainPath(_ settings: JSValue?) -> String {
+        if let toolchainPath = settings?["toolchainPath"].string {
             return toolchainPath
         }
 


### PR DESCRIPTION
This prevents a crash when trying to invoke the Sourcery wrapper with unset implicitely unwrapped optional attributes. I've had the issue with a LSP client which was not calling this event (FYI [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for emacs).
There is no absolute need to wait for the `DidChangeConfiguration` event to parse the `Package.swift` so this is now done on `initialize` but it will still be done if the workspace configuration changes.